### PR TITLE
Startup time improvement

### DIFF
--- a/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
+++ b/hibernate-core/src/main/java/org/hibernate/bytecode/internal/bytebuddy/BytecodeProviderImpl.java
@@ -197,17 +197,18 @@ public class BytecodeProviderImpl implements BytecodeProvider {
 				methodVisitor.visitVarInsn( Opcodes.ALOAD, 2 );
 				methodVisitor.visitLdcInsn( index++ );
 				methodVisitor.visitInsn( Opcodes.AALOAD );
-				if ( setter.getParameterTypes()[0].isPrimitive() ) {
+				Class<?> firstParameterType = setter.getParameterTypes()[0];
+				if ( firstParameterType.isPrimitive() ) {
 					PrimitiveUnboxingDelegate.forReferenceType( TypeDescription.Generic.OBJECT )
 							.assignUnboxedTo(
-									new TypeDescription.Generic.OfNonGenericType.ForLoadedType( setter.getParameterTypes()[0] ),
+									new TypeDescription.Generic.OfNonGenericType.ForLoadedType( firstParameterType ),
 									ReferenceTypeAwareAssigner.INSTANCE,
 									Assigner.Typing.DYNAMIC
 							)
 							.apply( methodVisitor, implementationContext );
 				}
 				else {
-					methodVisitor.visitTypeInsn( Opcodes.CHECKCAST, Type.getInternalName( setter.getParameterTypes()[0] ) );
+					methodVisitor.visitTypeInsn( Opcodes.CHECKCAST, Type.getInternalName( firstParameterType ) );
 				}
 				methodVisitor.visitMethodInsn(
 						Opcodes.INVOKEVIRTUAL,

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -513,8 +513,7 @@ public final class ReflectHelper {
 			// try "get"
 			if ( methodName.startsWith( "get" ) ) {
 				final String stemName = methodName.substring( 3 );
-				final String decapitalizedStemName = Introspector.decapitalize( stemName );
-				if ( stemName.equals( propertyName ) || decapitalizedStemName.equals( propertyName ) ) {
+				if ( stemName.equals( propertyName ) || Introspector.decapitalize( stemName ).equals( propertyName ) ) {
 					verifyNoIsVariantExists( containerClass, propertyName, method, stemName, declaredMethods);
 					return method;
 				}
@@ -524,8 +523,7 @@ public final class ReflectHelper {
 			// if not "get", then try "is"
 			if ( methodName.startsWith( "is" ) ) {
 				final String stemName = methodName.substring( 2 );
-				String decapitalizedStemName = Introspector.decapitalize( stemName );
-				if ( stemName.equals( propertyName ) || decapitalizedStemName.equals( propertyName ) ) {
+				if ( stemName.equals( propertyName ) || Introspector.decapitalize( stemName ).equals( propertyName ) ) {
 					verifyNoGetVariantExists( containerClass, propertyName, method, stemName, declaredMethods);
 					return method;
 				}
@@ -678,8 +676,7 @@ public final class ReflectHelper {
 			final String methodName = method.getName();
 			if ( method.getParameterCount() == 1 && methodName.startsWith( "set" ) ) {
 				final String testOldMethod = methodName.substring( 3 );
-				final String testStdMethod = Introspector.decapitalize( testOldMethod );
-				if ( testStdMethod.equals( propertyName ) || testOldMethod.equals( propertyName ) ) {
+				if (testOldMethod.equals( propertyName ) || Introspector.decapitalize( testOldMethod ).equals( propertyName )) {
 					potentialSetter = method;
 					if ( propertyType == null || method.getParameterTypes()[0].equals( propertyType ) ) {
 						break;
@@ -718,8 +715,7 @@ public final class ReflectHelper {
 			// try "get"
 			if ( methodName.startsWith( "get" ) ) {
 				final String stemName = methodName.substring( 3 );
-				final String decapitalizedStemName = Introspector.decapitalize( stemName );
-				if ( stemName.equals( propertyName ) || decapitalizedStemName.equals( propertyName ) ) {
+				if ( stemName.equals( propertyName ) || Introspector.decapitalize( stemName ).equals( propertyName ) ) {
 					return method;
 				}
 
@@ -728,8 +724,7 @@ public final class ReflectHelper {
 			// if not "get", then try "is"
 			if ( methodName.startsWith( "is" ) ) {
 				final String stemName = methodName.substring( 2 );
-				String decapitalizedStemName = Introspector.decapitalize( stemName );
-				if ( stemName.equals( propertyName ) || decapitalizedStemName.equals( propertyName ) ) {
+				if ( stemName.equals( propertyName ) || Introspector.decapitalize( stemName ).equals( propertyName ) ) {
 					return method;
 				}
 			}

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/ReflectHelper.java
@@ -423,16 +423,14 @@ public final class ReflectHelper {
 			return null;
 		}
 
-		try {
-			Field field = clazz.getDeclaredField( propertyName );
-			if ( !isStaticField( field ) ) {
-				return field;
-			}
+		Field field = findField(propertyName, clazz.getDeclaredFields());
+		if (field == null) {
 			return locateField( clazz.getSuperclass(), propertyName );
 		}
-		catch ( NoSuchFieldException nsfe ) {
-			return locateField( clazz.getSuperclass(), propertyName );
+		if ( !isStaticField( field ) ) {
+			return field;
 		}
+		return locateField( clazz.getSuperclass(), propertyName );
 	}
 
 	public static boolean isStaticField(Field field) {
@@ -541,6 +539,15 @@ public final class ReflectHelper {
 		for (Method method : methods) {
 			if (method.getName().equals(name)) {
 				return method;
+			}
+		}
+		return null;
+	}
+
+	private static Field findField(String name, Field[] methods) {
+		for (Field field : methods) {
+			if (field.getName().equals(name)) {
+				return field;
 			}
 		}
 		return null;

--- a/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
+++ b/hibernate-core/src/main/java/org/hibernate/internal/util/StringHelper.java
@@ -128,7 +128,10 @@ public final class StringHelper {
 			return template;
 		}
 		else {
-			String beforePlaceholder = template.substring( 0, loc );
+			String beforePlaceholder = "";
+			if (loc > 0) {
+				beforePlaceholder = template.substring(0, loc);
+			}
 			String afterPlaceholder = template.substring( loc + placeholder.length() );
 			return replace(
 					beforePlaceholder,


### PR DESCRIPTION
Relates to https://quarkusio.zulipchat.com/#narrow/stream/187030-users/topic/startup.20.2F.20reloading.20performance

d87ddc013afdf6df337d6f53972fc43a68c3f74b
Avoids a duplicate getParameterTypes() call, just for good measure.

37b219c8b187baea649d01c9a1b9b0fccd710cb6
Saves about 700ms. 

814559811c803082028bccbb23a8ec3e28e0fb82
Saves another 1s. This replaces a getDeclaredField call by getDeclaredFields and an iteration. Exceptions are apperantly more costly than creating lots of arrays copies.

8c319d71ca3ba892e42e8a81d6e2fe937735dccc
Saves another 300ms. This is the commit you worried about, implementing a simple cache for the class instances declared methods and fields.